### PR TITLE
fix(reconciler): avoid panic converting unstructured objects

### DIFF
--- a/reconciler.go
+++ b/reconciler.go
@@ -2,6 +2,7 @@ package kopper
 
 import (
 	gocontext "context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -94,7 +95,15 @@ func (r *Reconciler[T, PT]) Reconcile(ctx gocontext.Context, req ctrl.Request) (
 	resourceName := fmt.Sprintf("%s[%s/%s:%s]", r.gvk.Kind, req.Namespace, req.Name, raw.GetUID())
 
 	obj := PT(new(T))
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(raw.Object, obj); err != nil {
+	payload, err := json.Marshal(raw.Object)
+	if err != nil {
+		logger.Errorf("[kopper] malformed resource %s: %v", resourceName, err)
+		r.Events.Event(raw, "Warning", "MalformedResource",
+			fmt.Sprintf("Resource spec does not match expected schema: %v", err))
+		return ctrl.Result{}, fmt.Errorf("failed to marshal unstructured resource: %w", err)
+	}
+
+	if err := json.Unmarshal(payload, obj); err != nil {
 		logger.Errorf("[kopper] malformed resource %s: %v", resourceName, err)
 		r.Events.Event(raw, "Warning", "MalformedResource",
 			fmt.Sprintf("Resource spec does not match expected schema: %v", err))


### PR DESCRIPTION
`runtime.DefaultUnstructuredConverter.FromUnstructured(...)` uses reflection to populate every struct field of the destination type as it walks the object graph.

If it encounters an unexported field (lowercase field name), reflection cannot assign to it, and it panics with:

 reflect.Value.Set using value obtained using unexported field

---

Our CRDs have unexported fields like 
- view.query.http.awsConfig
- playbook.timeout

So the unstructured converter was not “wrong” generally; it’s just incompatible with typed graphs containing private fields in this decode path.

resolves: https://github.com/flanksource/mission-control/issues/2848
resolves: https://github.com/flanksource/mission-control/issues/2864