### PR TITLE
feat: Add StatusConditioner interface that allows kopper to set conditions on success and on failure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/jackc/pgerrcode v0.0.0-20240316143900-6e2875d9b438
 	github.com/jackc/pgx/v5 v5.6.0
+	github.com/samber/lo v1.47.0
 	k8s.io/apimachinery v0.31.1
 	k8s.io/client-go v0.31.1
 	sigs.k8s.io/controller-runtime v0.19.0
@@ -117,7 +118,6 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/robertkrimen/otto v0.3.0 // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
-	github.com/samber/lo v1.47.0 // indirect
 	github.com/samber/oops v1.13.1 // indirect
 	github.com/shirou/gopsutil/v3 v3.24.5 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect

--- a/reconciler.go
+++ b/reconciler.go
@@ -12,6 +12,8 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/samber/lo"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	k8smeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -28,12 +30,18 @@ type StatusPatchGenerator interface {
 	GenerateStatusPatch(previousState runtime.Object) client.Patch
 }
 
-// ReconcileStatusSetter allows a CRD to update its own status when a reconcile
-// operation fails. Kopper will call the appropriate method and write the status
-// back to Kubernetes automatically.
-type ReconcileStatusSetter interface {
-	SetUpsertErrorStatus(err error)
-	SetDeleteErrorStatus(err error)
+const (
+	ReadyConditionType = "Ready"
+
+	ReasonSynced        = "Synced"
+	ReasonPersistFailed = "PersistFailed"
+	ReasonDeleteFailed  = "DeleteFailed"
+)
+
+// StatusConditioner allows a CRD to expose its status conditions slice so
+// Kopper can set generic reconcile conditions.
+type StatusConditioner interface {
+	GetStatusConditions() *[]metav1.Condition
 }
 
 // OnUpsertFunc is a function that is called when a resource is created or updated
@@ -106,6 +114,29 @@ func (r *Reconciler[T, PT]) updateStatus(ctx gocontext.Context, resourceName str
 	return nil
 }
 
+func (r *Reconciler[T, PT]) setCondition(obj PT, status metav1.ConditionStatus, reason, message string) bool {
+	conditioner, ok := any(obj).(StatusConditioner)
+	if !ok {
+		return false
+	}
+
+	conditions := conditioner.GetStatusConditions()
+	if conditions == nil {
+		return false
+	}
+
+	k8smeta.SetStatusCondition(conditions, metav1.Condition{
+		Type:               ReadyConditionType,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: obj.GetGeneration(),
+		LastTransitionTime: metav1.Now(),
+	})
+
+	return true
+}
+
 func (r *Reconciler[T, PT]) Reconcile(ctx gocontext.Context, req ctrl.Request) (ctrl.Result, error) {
 	raw := &unstructured.Unstructured{}
 	raw.SetGroupVersionKind(r.gvk)
@@ -133,8 +164,7 @@ func (r *Reconciler[T, PT]) Reconcile(ctx gocontext.Context, req ctrl.Request) (
 		logger.V(2).Infof("[kopper] deleting %s", resourceName)
 		if err := r.OnDeleteFunc(r.DutyContext, string(obj.GetUID())); err != nil {
 			logger.Errorf("[kopper] failed to delete %s: %v", resourceName, err)
-			if setter, ok := any(obj).(ReconcileStatusSetter); ok {
-				setter.SetDeleteErrorStatus(err)
+			if r.setCondition(obj, metav1.ConditionFalse, ReasonDeleteFailed, err.Error()) {
 				if statusErr := r.updateStatus(ctx, resourceName, obj, original); statusErr != nil {
 					err = errors.Join(err, fmt.Errorf("failed to update status for %s: %w", resourceName, statusErr))
 				}
@@ -170,8 +200,7 @@ func (r *Reconciler[T, PT]) Reconcile(ctx gocontext.Context, req ctrl.Request) (
 		}
 
 		logger.Errorf("[kopper] failed to upsert %s: %v", resourceName, err)
-		if setter, ok := any(obj).(ReconcileStatusSetter); ok {
-			setter.SetUpsertErrorStatus(err)
+		if r.setCondition(obj, metav1.ConditionFalse, ReasonPersistFailed, err.Error()) {
 			if statusErr := r.updateStatus(ctx, resourceName, obj, original); statusErr != nil {
 				err = errors.Join(err, fmt.Errorf("failed to update status for %s: %w", resourceName, statusErr))
 			}
@@ -179,6 +208,7 @@ func (r *Reconciler[T, PT]) Reconcile(ctx gocontext.Context, req ctrl.Request) (
 		return ctrl.Result{Requeue: true, RequeueAfter: 2 * time.Minute}, err
 	}
 
+	r.setCondition(obj, metav1.ConditionTrue, ReasonSynced, "")
 	if err := r.updateStatus(ctx, resourceName, obj, original); err != nil {
 		return ctrl.Result{Requeue: true, RequeueAfter: 2 * time.Minute}, err
 	}

--- a/reconciler.go
+++ b/reconciler.go
@@ -28,6 +28,14 @@ type StatusPatchGenerator interface {
 	GenerateStatusPatch(previousState runtime.Object) client.Patch
 }
 
+// ReconcileStatusSetter allows a CRD to update its own status when a reconcile
+// operation fails. Kopper will call the appropriate method and write the status
+// back to Kubernetes automatically.
+type ReconcileStatusSetter interface {
+	SetUpsertErrorStatus(err error)
+	SetDeleteErrorStatus(err error)
+}
+
 // OnUpsertFunc is a function that is called when a resource is created or updated
 type OnUpsertFunc[PT client.Object] func(context.Context, PT) error
 
@@ -80,6 +88,24 @@ type Reconciler[T any, PT interface {
 	gvk            schema.GroupVersionKind
 }
 
+func (r *Reconciler[T, PT]) updateStatus(ctx gocontext.Context, resourceName string, obj PT, original runtime.Object) error {
+	if mgr, ok := any(obj).(StatusPatchGenerator); ok {
+		if patch := mgr.GenerateStatusPatch(original); patch != nil {
+			if err := r.Status().Patch(ctx, obj, patch); err != nil {
+				logger.Errorf("[kopper] failed to update status %s: %v", resourceName, err)
+				return err
+			}
+		}
+	} else {
+		if err := r.Status().Update(ctx, obj); err != nil {
+			logger.Errorf("[kopper] failed to update status %s: %v", resourceName, err)
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (r *Reconciler[T, PT]) Reconcile(ctx gocontext.Context, req ctrl.Request) (ctrl.Result, error) {
 	raw := &unstructured.Unstructured{}
 	raw.SetGroupVersionKind(r.gvk)
@@ -107,6 +133,12 @@ func (r *Reconciler[T, PT]) Reconcile(ctx gocontext.Context, req ctrl.Request) (
 		logger.V(2).Infof("[kopper] deleting %s", resourceName)
 		if err := r.OnDeleteFunc(r.DutyContext, string(obj.GetUID())); err != nil {
 			logger.Errorf("[kopper] failed to delete %s: %v", resourceName, err)
+			if setter, ok := any(obj).(ReconcileStatusSetter); ok {
+				setter.SetDeleteErrorStatus(err)
+				if statusErr := r.updateStatus(ctx, resourceName, obj, original); statusErr != nil {
+					err = errors.Join(err, fmt.Errorf("failed to update status for %s: %w", resourceName, statusErr))
+				}
+			}
 			return ctrl.Result{Requeue: true, RequeueAfter: 2 * time.Minute}, err
 		}
 		controllerutil.RemoveFinalizer(obj, r.Finalizer)
@@ -138,23 +170,17 @@ func (r *Reconciler[T, PT]) Reconcile(ctx gocontext.Context, req ctrl.Request) (
 		}
 
 		logger.Errorf("[kopper] failed to upsert %s: %v", resourceName, err)
+		if setter, ok := any(obj).(ReconcileStatusSetter); ok {
+			setter.SetUpsertErrorStatus(err)
+			if statusErr := r.updateStatus(ctx, resourceName, obj, original); statusErr != nil {
+				err = errors.Join(err, fmt.Errorf("failed to update status for %s: %w", resourceName, statusErr))
+			}
+		}
 		return ctrl.Result{Requeue: true, RequeueAfter: 2 * time.Minute}, err
 	}
 
-	if mgr, ok := any(obj).(StatusPatchGenerator); ok {
-		if patch := mgr.GenerateStatusPatch(original); patch != nil {
-			if err := r.Status().Patch(r.DutyContext, obj, patch); err != nil {
-				logger.Errorf("[kopper] failed to update status %s: %v", resourceName, err)
-				return ctrl.Result{Requeue: true, RequeueAfter: 2 * time.Minute}, err
-			}
-		}
-	} else {
-		// TODO: only for backward compatibility
-		// remove later ..
-		if err := r.Status().Update(r.DutyContext, obj); err != nil {
-			logger.Errorf("[kopper] failed to update status %s: %v", resourceName, err)
-			return ctrl.Result{Requeue: true, RequeueAfter: 2 * time.Minute}, err
-		}
+	if err := r.updateStatus(ctx, resourceName, obj, original); err != nil {
+		return ctrl.Result{Requeue: true, RequeueAfter: 2 * time.Minute}, err
 	}
 
 	action := lo.Ternary(isCreated, "Created", "Updated")


### PR DESCRIPTION
Removes huge boilerplate from all of our resources. 

Example: all the kubernetes status andling in `db` package here: https://github.com/flanksource/mission-control/blob/6e8c19f2c42b4a0f046aa4bc49f9b0f5beb8294e/db/views.go