### PR TITLE
fix: sync status.observedGeneration independently of status conditions

### DIFF
--- a/reconciler.go
+++ b/reconciler.go
@@ -102,6 +102,12 @@ type Reconciler[T any, PT interface {
 	gvk            schema.GroupVersionKind
 }
 
+func (r *Reconciler[T, PT]) syncObservedGeneration(obj PT) {
+	if setter, ok := any(obj).(ObservedGenerationSetter); ok {
+		setter.SetObservedGeneration(obj.GetGeneration())
+	}
+}
+
 func (r *Reconciler[T, PT]) updateStatus(ctx gocontext.Context, resourceName string, obj PT, original runtime.Object) error {
 	if mgr, ok := any(obj).(StatusPatchGenerator); ok {
 		if patch := mgr.GenerateStatusPatch(original); patch != nil {
@@ -140,10 +146,6 @@ func (r *Reconciler[T, PT]) setCondition(obj PT, status metav1.ConditionStatus, 
 		LastTransitionTime: metav1.Now(),
 	})
 
-	if setter, ok := any(obj).(ObservedGenerationSetter); ok {
-		setter.SetObservedGeneration(obj.GetGeneration())
-	}
-
 	return true
 }
 
@@ -174,10 +176,10 @@ func (r *Reconciler[T, PT]) Reconcile(ctx gocontext.Context, req ctrl.Request) (
 		logger.V(2).Infof("[kopper] deleting %s", resourceName)
 		if err := r.OnDeleteFunc(r.DutyContext, string(obj.GetUID())); err != nil {
 			logger.Errorf("[kopper] failed to delete %s: %v", resourceName, err)
-			if r.setCondition(obj, metav1.ConditionFalse, ReasonDeleteFailed, err.Error()) {
-				if statusErr := r.updateStatus(ctx, resourceName, obj, original); statusErr != nil {
-					err = errors.Join(err, fmt.Errorf("failed to update status for %s: %w", resourceName, statusErr))
-				}
+			r.setCondition(obj, metav1.ConditionFalse, ReasonDeleteFailed, err.Error())
+			r.syncObservedGeneration(obj)
+			if statusErr := r.updateStatus(ctx, resourceName, obj, original); statusErr != nil {
+				err = errors.Join(err, fmt.Errorf("failed to update status for %s: %w", resourceName, statusErr))
 			}
 			return ctrl.Result{Requeue: true, RequeueAfter: 2 * time.Minute}, err
 		}
@@ -210,15 +212,16 @@ func (r *Reconciler[T, PT]) Reconcile(ctx gocontext.Context, req ctrl.Request) (
 		}
 
 		logger.Errorf("[kopper] failed to upsert %s: %v", resourceName, err)
-		if r.setCondition(obj, metav1.ConditionFalse, ReasonPersistFailed, err.Error()) {
-			if statusErr := r.updateStatus(ctx, resourceName, obj, original); statusErr != nil {
-				err = errors.Join(err, fmt.Errorf("failed to update status for %s: %w", resourceName, statusErr))
-			}
+		r.setCondition(obj, metav1.ConditionFalse, ReasonPersistFailed, err.Error())
+		r.syncObservedGeneration(obj)
+		if statusErr := r.updateStatus(ctx, resourceName, obj, original); statusErr != nil {
+			err = errors.Join(err, fmt.Errorf("failed to update status for %s: %w", resourceName, statusErr))
 		}
 		return ctrl.Result{Requeue: true, RequeueAfter: 2 * time.Minute}, err
 	}
 
 	r.setCondition(obj, metav1.ConditionTrue, ReasonSynced, "")
+	r.syncObservedGeneration(obj)
 	if err := r.updateStatus(ctx, resourceName, obj, original); err != nil {
 		return ctrl.Result{Requeue: true, RequeueAfter: 2 * time.Minute}, err
 	}

--- a/reconciler.go
+++ b/reconciler.go
@@ -44,6 +44,12 @@ type StatusConditioner interface {
 	GetStatusConditions() *[]metav1.Condition
 }
 
+// ObservedGenerationSetter allows a CRD to have its top-level
+// status.observedGeneration kept in sync by Kopper on each reconcile.
+type ObservedGenerationSetter interface {
+	SetObservedGeneration(generation int64)
+}
+
 // OnUpsertFunc is a function that is called when a resource is created or updated
 type OnUpsertFunc[PT client.Object] func(context.Context, PT) error
 
@@ -133,6 +139,10 @@ func (r *Reconciler[T, PT]) setCondition(obj PT, status metav1.ConditionStatus, 
 		ObservedGeneration: obj.GetGeneration(),
 		LastTransitionTime: metav1.Now(),
 	})
+
+	if setter, ok := any(obj).(ObservedGenerationSetter); ok {
+		setter.SetObservedGeneration(obj.GetGeneration())
+	}
 
 	return true
 }

--- a/reconciler.go
+++ b/reconciler.go
@@ -102,10 +102,12 @@ type Reconciler[T any, PT interface {
 	gvk            schema.GroupVersionKind
 }
 
-func (r *Reconciler[T, PT]) syncObservedGeneration(obj PT) {
+func (r *Reconciler[T, PT]) syncObservedGeneration(obj PT) bool {
 	if setter, ok := any(obj).(ObservedGenerationSetter); ok {
 		setter.SetObservedGeneration(obj.GetGeneration())
+		return true
 	}
+	return false
 }
 
 func (r *Reconciler[T, PT]) updateStatus(ctx gocontext.Context, resourceName string, obj PT, original runtime.Object) error {
@@ -176,10 +178,10 @@ func (r *Reconciler[T, PT]) Reconcile(ctx gocontext.Context, req ctrl.Request) (
 		logger.V(2).Infof("[kopper] deleting %s", resourceName)
 		if err := r.OnDeleteFunc(r.DutyContext, string(obj.GetUID())); err != nil {
 			logger.Errorf("[kopper] failed to delete %s: %v", resourceName, err)
-			r.setCondition(obj, metav1.ConditionFalse, ReasonDeleteFailed, err.Error())
-			r.syncObservedGeneration(obj)
-			if statusErr := r.updateStatus(ctx, resourceName, obj, original); statusErr != nil {
-				err = errors.Join(err, fmt.Errorf("failed to update status for %s: %w", resourceName, statusErr))
+			if r.setCondition(obj, metav1.ConditionFalse, ReasonDeleteFailed, err.Error()) || r.syncObservedGeneration(obj) {
+				if statusErr := r.updateStatus(ctx, resourceName, obj, original); statusErr != nil {
+					err = errors.Join(err, fmt.Errorf("failed to update status for %s: %w", resourceName, statusErr))
+				}
 			}
 			return ctrl.Result{Requeue: true, RequeueAfter: 2 * time.Minute}, err
 		}
@@ -212,10 +214,10 @@ func (r *Reconciler[T, PT]) Reconcile(ctx gocontext.Context, req ctrl.Request) (
 		}
 
 		logger.Errorf("[kopper] failed to upsert %s: %v", resourceName, err)
-		r.setCondition(obj, metav1.ConditionFalse, ReasonPersistFailed, err.Error())
-		r.syncObservedGeneration(obj)
-		if statusErr := r.updateStatus(ctx, resourceName, obj, original); statusErr != nil {
-			err = errors.Join(err, fmt.Errorf("failed to update status for %s: %w", resourceName, statusErr))
+		if r.setCondition(obj, metav1.ConditionFalse, ReasonPersistFailed, err.Error()) || r.syncObservedGeneration(obj) {
+			if statusErr := r.updateStatus(ctx, resourceName, obj, original); statusErr != nil {
+				err = errors.Join(err, fmt.Errorf("failed to update status for %s: %w", resourceName, statusErr))
+			}
 		}
 		return ctrl.Result{Requeue: true, RequeueAfter: 2 * time.Minute}, err
 	}


### PR DESCRIPTION
Adds `ObservedGenerationSetter` interface — CRDs that implement `SetObservedGeneration(int64)` will have their top-level `status.observedGeneration` kept in sync by Kopper on every reconcile, regardless of whether they also implement `StatusConditioner`.