### PR TITLE
fix: restrict lint workflow permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Lint
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   golangci:
     name: lint


### PR DESCRIPTION
resolves: https://github.com/flanksource/kopper/security/code-scanning/5